### PR TITLE
Replace reuse queue with a pool allocator of fixed size blocks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ m4_define([NC_BUGS], [manj@cs.stanford.edu])
 
 # Initialize autoconf
 AC_PREREQ([2.64])
-AC_INIT([nutcracker], [NC_MAJOR.NC_MINOR.NC_PATCH], [NC_BUGS])
+AC_INIT([nutcracker],[NC_MAJOR.NC_MINOR.NC_PATCH],[NC_BUGS])
 AC_CONFIG_SRCDIR([src/nc.c])
 AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_HEADERS([config.h:config.h.in])
@@ -33,7 +33,7 @@ AC_PROG_INSTALL
 AC_PROG_LN_S
 AC_PROG_MAKE_SET
 AC_PROG_RANLIB
-AC_PROG_LIBTOOL
+LT_INIT
 
 # Checks for typedefs, structures, and compiler characteristics
 AC_C_INLINE
@@ -86,7 +86,7 @@ AC_CHECK_FUNCS([memchr memmove memset])
 AC_CHECK_FUNCS([strchr strndup strtoul])
 
 AC_CACHE_CHECK([if epoll works], [ac_cv_epoll_works],
-  AC_TRY_RUN([
+  AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/epoll.h>
@@ -102,12 +102,12 @@ main(int argc, char **argv)
     }
     exit(0);
 }
-  ], [ac_cv_epoll_works=yes], [ac_cv_epoll_works=no]))
+  ]])],[ac_cv_epoll_works=yes],[ac_cv_epoll_works=no],[]))
 AS_IF([test "x$ac_cv_epoll_works" = "xyes"],
   [AC_DEFINE([HAVE_EPOLL], [1], [Define to 1 if epoll is supported])], [])
 
 AC_CACHE_CHECK([if kqueue works], [ac_cv_kqueue_works],
-  AC_TRY_RUN([
+  AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
@@ -125,12 +125,12 @@ main(int argc, char **argv)
     }
     exit(0);
 }
-  ], [ac_cv_kqueue_works=yes], [ac_cv_kqueue_works=no]))
+  ]])],[ac_cv_kqueue_works=yes],[ac_cv_kqueue_works=no],[]))
 AS_IF([test "x$ac_cv_kqueue_works" = "xyes"],
   [AC_DEFINE([HAVE_KQUEUE], [1], [Define to 1 if kqueue is supported])], [])
 
 AC_CACHE_CHECK([if event ports works], [ac_cv_evports_works],
-  AC_TRY_RUN([
+  AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <stdio.h>
 #include <stdlib.h>
 #include <port.h>
@@ -146,7 +146,7 @@ main(int argc, char **argv)
     }
     exit(0);
 }
-  ], [ac_cv_evports_works=yes], [ac_cv_evports_works=no]))
+  ]])],[ac_cv_evports_works=yes],[ac_cv_evports_works=no],[]))
 AS_IF([test "x$ac_cv_evports_works" = "xyes"],
   [AC_DEFINE([HAVE_EVENT_PORTS], [1], [Define to 1 if event ports is supported])], [])
 

--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,7 @@ AC_DEFINE(NC_VERSION_STRING, "NC_MAJOR.NC_MINOR.NC_PATCH", [Define the version s
 
 # Checks for language
 AC_LANG([C])
+AC_LANG([C++])
 
 # Checks for programs
 AC_PROG_AWK
@@ -71,6 +72,7 @@ AC_CHECK_HEADERS([execinfo.h],
   [AC_DEFINE(HAVE_BACKTRACE, [1], [Define to 1 if backtrace is supported])], [])
 AC_CHECK_HEADERS([sys/epoll.h], [], [])
 AC_CHECK_HEADERS([sys/event.h], [], [])
+AC_CHECK_HEADERS([boost/pool/pool.hpp], [], [AC_MSG_ERROR(Boost library missing)])
 
 # Checks for libraries
 AC_CHECK_LIB([m], [pow])
@@ -208,7 +210,8 @@ AC_CONFIG_FILES([Makefile
                  src/Makefile
                  src/hashkit/Makefile
                  src/proto/Makefile
-                 src/event/Makefile])
+                 src/event/Makefile
+                 src/alloc/Makefile])
 
 # Generate the "configure" script
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -8,6 +8,7 @@ AM_CPPFLAGS += -I $(top_srcdir)/src/hashkit
 AM_CPPFLAGS += -I $(top_srcdir)/src/proto
 AM_CPPFLAGS += -I $(top_srcdir)/src/event
 AM_CPPFLAGS += -I $(top_srcdir)/contrib/yaml-0.1.4/include
+AM_CPPFLAGS += -I $(top_srcdir)/src/alloc
 
 AM_CFLAGS = 
 # about -fno-strict-aliasing: https://github.com/twitter/twemproxy/issues/276
@@ -29,7 +30,7 @@ if OS_FREEBSD
 AM_LDFLAGS += -lexecinfo
 endif
 
-SUBDIRS = hashkit proto event
+SUBDIRS = hashkit proto event alloc
 
 sbin_PROGRAMS = nutcracker
 
@@ -57,4 +58,5 @@ nutcracker_SOURCES =			\
 nutcracker_LDADD = $(top_builddir)/src/hashkit/libhashkit.a
 nutcracker_LDADD += $(top_builddir)/src/proto/libproto.a
 nutcracker_LDADD += $(top_builddir)/src/event/libevent.a
+nutcracker_LDADD += $(top_builddir)/src/alloc/liballoc.a
 nutcracker_LDADD += $(top_builddir)/contrib/yaml-0.1.4/src/.libs/libyaml.a

--- a/src/alloc/Makefile.am
+++ b/src/alloc/Makefile.am
@@ -1,0 +1,10 @@
+MAINTAINERCLEANFILES = Makefile.in
+
+noinst_LIBRARIES = liballoc.a
+
+noinst_HEADERS = alloc.h
+
+AM_CXXFLAGS = -static-libstdc++ -fno-exceptions -fno-rtti
+
+liballoc_a_SOURCES =		\
+	alloc.cpp

--- a/src/alloc/alloc.cpp
+++ b/src/alloc/alloc.cpp
@@ -1,0 +1,33 @@
+// Implements in C a simple pool allocator using boost::pool
+
+#include <boost/pool/pool.hpp>
+
+using alloc_t = boost::pool<boost::default_user_allocator_malloc_free>;
+
+extern "C" {
+
+void *new_pool_allocator(size_t length) noexcept {
+  // using standard new would require to implement:
+  //  void *operator new (size_t)
+  auto ptr = malloc(sizeof(alloc_t));
+  return new (ptr) alloc_t(length);
+}
+
+void *pool_allocator_alloc(void *handle) noexcept {
+  return reinterpret_cast<alloc_t *>(handle)->malloc();
+}
+
+void pool_allocator_free(void *handle, void *addr) noexcept {
+  if (addr == nullptr)
+    return;
+  reinterpret_cast<alloc_t *>(handle)->free(addr);
+}
+
+void delete_pool_allocator(void *handle) noexcept {
+  // using standard delete would require to implement:
+  //  void operator delete(void *, size_t)' function
+  auto ptr = reinterpret_cast<alloc_t *>(handle);
+  ptr->~alloc_t();
+  free(ptr);
+}
+}

--- a/src/alloc/alloc.h
+++ b/src/alloc/alloc.h
@@ -1,0 +1,13 @@
+/*
+    Simple pool allocator
+    Uses boost::pool
+*/
+
+#include <stddef.h>
+
+struct pool_allocator;
+
+struct pool_allocator *new_pool_allocator(size_t);
+void *pool_allocator_alloc(struct pool_allocator *handle);
+void pool_allocator_free(struct pool_allocator *handle, void *item);
+void delete_pool_allocator(struct pool_allocator *handle);


### PR DESCRIPTION
Problem

Twemproxy's solution to having to allocate many small memory blocks of the same size was to use reuse queues.

The issues with that approach are as follow:
- Memory footprint can only increase as allocated blocks are never freed.
- During spikes the queue might get empty and what we were trying to avoid (bunch of small malloc calls) will happen anyway.

Solution

Memory pools are made for this kind of situation.
Citing [boost's pool documentation](https://www.boost.org/doc/libs/1_66_0/libs/pool/doc/html/boost_pool/pool/introduction.html):
> Why should I use Pool?
Using Pools gives you more control over how memory is used in your program. For example, you could have a situation where you want to allocate a bunch of small objects at one point, and then reach a point in your program where none of them are needed any more. Using pool interfaces, you can choose to run their destructors or just drop them off into oblivion; the pool interface will guarantee that there are no system memory leaks.

This reduces the memory footprint and the number of malloc/free calls.
Solving both of our issues.

Boost's pool was chosen as its a well-maintained library with minimal dependencies.
We produced a standalone static library usable from C.
Only building requires a C++ compiler and the Boost library.

Describe the modifications you've done.

- Add C binding static library to Boost's pool library
- Replace uses of reuses queue with said library
